### PR TITLE
No LayerNorm in case of parallel attention

### DIFF
--- a/examples/speech_recognition/modules/conv_transformer_context_layer.py
+++ b/examples/speech_recognition/modules/conv_transformer_context_layer.py
@@ -19,7 +19,8 @@ class ConvTransformerContextAwareEncoderLayer(ConvTransformerEncoderLayer):
             )
             self.context_gating_wi = Linear(self.embed_dim, self.embed_dim)
             self.context_gating_ws = Linear(self.embed_dim, self.embed_dim)
-            self.context_layer_norm = LayerNorm(self.embed_dim)
+            if self.context_attention_type == "sequential":
+                self.context_layer_norm = LayerNorm(self.embed_dim)
 
     def forward(
             self,


### PR DESCRIPTION
Avoid instantiating LayerNorm module in case of parallel attention otherwise you get errors in the DistributedDataParallel of pytorch in the loss computation.